### PR TITLE
feature: add manifest file

### DIFF
--- a/bundlr/manifest.go
+++ b/bundlr/manifest.go
@@ -1,0 +1,15 @@
+package bundlr
+
+const (
+	manifestFilename = "manifest.json"
+)
+
+// UserData allows to store any KV information
+type UserData map[string]interface{}
+
+// Manifest stores bundle metadata
+// It is written as a json file at the root level of the bundle
+type Manifest struct {
+	Version  string   `json:"version"`
+	UserData UserData `json:"userdata"`
+}

--- a/bundlr/manifest_test.go
+++ b/bundlr/manifest_test.go
@@ -1,0 +1,34 @@
+package bundlr
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBundle_Manifest(t *testing.T) {
+	const version = "1.0"
+
+	bundle, err := OpenBundle(afero.NewMemMapFs(), "/tmp/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := bundle.Manifest()
+	assert.Nil(t, err)
+	assert.Equal(t, &Manifest{}, manifest)
+
+	manifest.Version = version
+	manifest.UserData = UserData{
+		"codec": "csv",
+	}
+
+	assert.NoError(t, bundle.WriteManifest(manifest))
+
+	manifest, err = bundle.Manifest()
+	assert.Nil(t, err)
+	assert.NotNil(t, manifest)
+	assert.Equal(t, version, manifest.Version)
+	assert.Equal(t, "csv", manifest.UserData["codec"])
+}


### PR DESCRIPTION
Add a manifest file at the root level of the bundle.
It allows storing metadata information regarding the bundle, such as
a `version` and an application ID. UserData is available for use at the
discretion of the user.