### PR TITLE
feat: add manifest schema version

### DIFF
--- a/bundlr/manifest.go
+++ b/bundlr/manifest.go
@@ -2,6 +2,9 @@ package bundlr
 
 const (
 	manifestFilename = "manifest.json"
+
+	// Manifest schema version
+	ManifestVersion = "1.0"
 )
 
 // UserData allows to store any KV information


### PR DESCRIPTION
Proposing to expose the current Manifest schema version to be accessible for external use.