### PR TITLE
bugfix(bundlr.writer): initialize encoder as part of writer constructor

### DIFF
--- a/bundlr/writer.go
+++ b/bundlr/writer.go
@@ -46,6 +46,10 @@ func NewWriter(b *Bundle, n uint64) (*Writer, error) {
 		w.partIndex = parsePartIndexFromFileName(files[len(files)-1].Name())
 	}
 
+	if err := w.getNewEncoderIfNeeded(); err != nil {
+		return nil, err
+	}
+
 	return w, nil
 }
 

--- a/codecs/parquet/parquet_test.go
+++ b/codecs/parquet/parquet_test.go
@@ -62,3 +62,28 @@ func TestWriteReadDelete(t *testing.T) {
 	// Delete
 	assert.NoError(t, bundle.Delete(), "bundle.Delete()")
 }
+
+func TestWriteEmptyFile(t *testing.T) {
+	fs := afero.NewOsFs()
+	name := "parquetEmptyTest.bundle"
+	bundle, err := bundlr.OpenBundle(fs, name)
+	assert.NoError(t, err, "OpenBundle(...)")
+	bundle = ConfigBundle(bundle, new(Student))
+
+	writer, err := bundle.Writer()
+	assert.NoError(t, err, "bundle.Writer()")
+	assert.NoError(t, writer.Close(), "writer.Close()")
+
+	// Read
+	reader, err := bundle.Reader()
+	assert.NoError(t, err, "bundle.Reader()")
+
+	st := make([]Student, 0)
+	err = reader.Read(&st)
+	assert.Error(t, err)
+	assert.EqualError(t, io.EOF, err.Error())
+	assert.NoError(t, reader.Close(), "reader.Close()")
+
+	// Delete
+	assert.NoError(t, bundle.Delete(), "bundle.Delete()")
+}


### PR DESCRIPTION
Expectations: header rows are being written to file if a Parquet file has no rows.

[`bundlr.Writer.Encoder` ](https://pkg.go.dev/github.com/popbones/bundlr-go/bundlr#Encoder)is only being initialized when the [`bundlr.Writer`](https://pkg.go.dev/github.com/popbones/bundlr-go/bundlr#Writer) performs [its first write](https://github.com/popbones/bundlr-go/blob/b21f870faee6/bundlr/writer.go#L59) to the filesystem. When the `bundlr.Writer` is being closed, as the encoder has not been initialized yet, [the encoder does not get closed](https://github.com/popbones/bundlr-go/blob/b21f870faee6/bundlr/writer.go#L82-L84). As a result, no data get flushed to disk.

This is an issue for schema-based codecs, such as parquet, where may want to write the headers down even if no rows have been written. See [`ParquetWriter.WriteStop`](https://godoc.org/github.com/xitongsys/parquet-go/writer#ParquetWriter.WriteStop) writing the footer that expects to be called from the codec [there](https://github.com/popbones/bundlr-go/blob/master/codecs/parquet/encoder.go#L50).